### PR TITLE
perf: cache statements

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -46,6 +46,18 @@ fn lam_default_store(bencher: &mut Bencher) {
     bencher.iter(|| e.evaluate().unwrap());
 }
 
+fn lam_update(bencher: &mut Bencher) {
+    let script = r#"
+    return require('@lam'):update('a', function(v)
+        return v+1
+    end, 0)
+    "#;
+    let e = EvaluationBuilder::new(script, empty())
+        .with_default_store()
+        .build();
+    bencher.iter(|| e.evaluate().unwrap());
+}
+
 /// read
 
 fn lam_read_all(bencher: &mut Bencher) {
@@ -111,5 +123,5 @@ benchmark_group!(
     lam_read_unicode,
     read_from_buf_reader,
 );
-benchmark_group!(store, lam_default_store, lam_no_store);
+benchmark_group!(store, lam_default_store, lam_no_store, lam_update);
 benchmark_main!(evaluation, read, store);


### PR DESCRIPTION
# Command

```
RUST_LOG=error ./target/release/lam example serve --name store
```

## Before

```
Running 10s test @ http://localhost:3000
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   643.71us  143.38us   2.27ms   75.18%
    Req/Sec     7.75k   349.89     8.39k    69.31%
  155700 requests in 10.10s, 18.01MB read
Requests/sec:  15415.39
Transfer/sec:      1.78MB
```

## After

```
Running 10s test @ http://localhost:3000
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   511.43us  101.64us   7.33ms   81.78%
    Req/Sec     9.73k   375.50    10.62k    64.36%
  195488 requests in 10.10s, 22.64MB read
Requests/sec:  19356.43
Transfer/sec:      2.24MB
```
